### PR TITLE
Feature/koala gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,9 @@ gem 'faker'
 # Devise Authentication
 gem 'devise'
 
+# Koala Gem
+gem 'koala'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,8 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     arel (8.0.0)
     ast (2.3.0)
     autoprefixer-rails (7.1.6)
@@ -75,6 +77,8 @@ GEM
       railties (>= 3.0.0)
     faker (1.8.4)
       i18n (~> 0.5)
+    faraday (0.13.1)
+      multipart-post (>= 1.2, < 3)
     ffi (1.9.18)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
@@ -87,6 +91,11 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    json (2.1.0)
+    koala (3.0.0)
+      addressable
+      faraday
+      json (>= 1.8)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -101,6 +110,7 @@ GEM
     mini_portile2 (2.3.0)
     minitest (5.10.3)
     multi_json (1.12.2)
+    multipart-post (2.0.0)
     nio4r (2.1.0)
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
@@ -111,6 +121,7 @@ GEM
     pg (0.21.0)
     popper_js (1.12.5)
     powerpack (0.1.1)
+    public_suffix (3.0.1)
     puma (3.10.0)
     rack (2.0.3)
     rack-test (0.7.0)
@@ -239,6 +250,7 @@ DEPENDENCIES
   faker
   jbuilder (~> 2.5)
   jquery-rails
+  koala
   listen (>= 3.0.5, < 3.2)
   pg (~> 0.18)
   puma (~> 3.7)

--- a/app/controllers/apis_controller.rb
+++ b/app/controllers/apis_controller.rb
@@ -14,13 +14,21 @@ class ApisController < ApplicationController
 
   def retrieve
     # we are passing in the url_string to the GetApi service
-    @service = GetApiService.call("https://graph.facebook.com/v2.11/801300133319963_1476720132444623/insights/post_reactions_like_total?access_token=EAACEdEose0cBAAT9ZB1aiGIOA4h3iDbo6JNYDCfCCMe758T7qDJge8GZAwx0BxyOut0xAWxnTlG4PbC2uA8G1uI3s4UayLZARSlW4WBviUpX5Ni5fSZAfbcsWW48aI0nCfdfajDi5vYfv0KYkKoTMnsjLVzFIz3olpHJDwMDBl992zn38AYbefSl9JvG1qgZD")
-
+    @service = GetApiService.call("https://graph.facebook.com/v2.11/801300133319963_1476720132444623/insights/post_reactions_like_total?access_token=EAACEdEose0cBAMd49w42KdWwmdKbMCsJRZAkk04sKNQnRDem73yQ40r2gsDmUBwzB5Xf5tnoFrsZCZCkwjM0RsMXJaUZCuCndtC4ye18hIV8u0Kgq149SxsvZALs7ZBZA4GC6ZAqh44qmw8DG4ThyT40AOIIfbOhv6ZAAzRe9uO1p4xA5gkZCoXcs1MF82aGG6Ja8ZD")
     puts @service
+  end
 
-    # save into seed?
-    # save into database?
+  def facebook
+    @graph = Koala::Facebook::API.new('EAACEdEose0cBADvg3oPOrppn8gUKJa834rV5uTF3cIwD5W0iH3KgsuZCqGFullUZA0wJT1AjO5t1PDRdyBGOdsxMVFAtJQaWirZCUyQJmfuA5GjAOqpMZB3uN5jNpJf1wMICrAv8cT79fumTT3B6tLbF3DGZAsUSoMmUY2b3ZC8VpygFG5ZCORpZA0jlfoEucVoZD')
 
+    @post= @graph.get_connections("801300133319963","posts")
+
+    @impressions = @graph.get_connection('801300133319963_1359160674200570', 'insights', metric: 'post_impressions_unique, post_stories_by_action_type, post_reactions_by_type_total, post_consumptions, post_consumptions_by_type', period: 'lifetime')
+
+    @likes= @graph.get_object('801300133319963_1392566647526639', fields: "shares.summary(true), likes.limit(0).summary(true),comments.limit(0).summary(true)")
+
+    puts @likes
+    puts @impressions
   end
 
 end

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -5,3 +5,4 @@ require_relative 'application'
 Rails.application.initialize!
 
 require 'net/http'
+require 'koala'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,5 +11,6 @@ Rails.application.routes.draw do
   end
 
   get 'apis/retrieve', to: 'apis#retrieve'
+  get 'apis/facebook', to: 'apis#facebook'
 
 end


### PR DESCRIPTION
## Overview
- Add koala gem and config
- Add facebook controller action to ApisController to retrieve insights 

## Screenshots
![image](https://user-images.githubusercontent.com/27413341/33512660-6d5aa404-d76f-11e7-8114-64324365c98e.png)

## Notes
- App Access token required from facebook's graph api explorer tool, has expiry time
- facebook post_id required